### PR TITLE
fix(linter): turn off @next/no-page-custom-font

### DIFF
--- a/tooling/eslint/nextjs.js
+++ b/tooling/eslint/nextjs.js
@@ -12,6 +12,7 @@ export default [
       ...nextPlugin.configs["core-web-vitals"].rules,
       // TypeError: context.getAncestors is not a function
       "@next/next/no-duplicate-head": "off",
+      "@next/next/no-page-custom-font": "off",
     },
   },
 ];


### PR DESCRIPTION
I noticed that in the `nextjs.js` lint file the `@next/next/no-duplicate-head` rule is turned off to avoid the `context.getAncestors is not a function` error. This PR also turns off the `@next/next/no-page-custom-font` rule as this also currently throws the same error for me in Next.js 14.2.13.